### PR TITLE
Update

### DIFF
--- a/_grids-semantic.scss
+++ b/_grids-semantic.scss
@@ -22,17 +22,18 @@ $gridWidth      : $totalColumns * ($columnWidth + $gutterWidth);
 // Each column
 @mixin column($n) {
 	width: col($n);
-	margin-left: percentage( $gutterWidth / $gridWidth );
+	margin-left: percentage( $gutterWidth / $gridWidth / 2 );
+	margin-right: percentage( $gutterWidth / $gridWidth / 2 );
 }
 
 // Grid container
 .grids {
 	width: auto;
 	max-width: $gridWidth;
-	margin-left: -(percentage( $gutterWidth / $gridWidth ));
 	clear: both;
 	list-style: none;
 	overflow: hidden;
+	margin: 0 auto;
 }
 
 // Generates placeholders instead of styles, these won't be output in our CSS

--- a/_grids.scss
+++ b/_grids.scss
@@ -22,17 +22,18 @@ $gridWidth      : $totalColumns * ($columnWidth + $gutterWidth);
 // Each column
 @mixin column($n) {
 	width: col($n);
-	margin-left: percentage( $gutterWidth / $gridWidth );
+	margin-left: percentage( $gutterWidth / $gridWidth / 2 );
+	margin-right: percentage( $gutterWidth / $gridWidth / 2 );
 }
 
 // Grid container
 .grids {
 	width: auto;
 	max-width: $gridWidth;
-	margin-left: -(percentage( $gutterWidth / $gridWidth ));
 	clear: both;
 	list-style: none;
 	overflow: hidden;
+	margin: 0 auto;
 }
 
 // Generates styles


### PR DESCRIPTION
Hi there, this is my first pull request. I hope you like !

I've adjusted this grid to fit better with more modern grids.

That being, rather than having a margin-left of the gutter width. You have it split between a margin-right and margin-left.

E.g.
Previous: margin-left: 2%;
Revised: margin-left: 1%; margin-right: 1%;

What this allows is to have gutter on either side of the container too, but not on the container element itself.

I also removed the negative margin-left on the .grids container and changed it to margin: 0 auto; to center it.

I realise this was based on Harry Robert's Fluid Grid Calculator but there seems to be a 404 on his link. This essentially does the same thing I believe however.
